### PR TITLE
Bugfix so pdfinfo will not crash if file passed to it is not a PDF

### DIFF
--- a/lib/pdfinfo.js
+++ b/lib/pdfinfo.js
@@ -126,9 +126,11 @@ function map (results) {
 
   var meta = {};
 
-  for (var i=0; i < results.length; i++) {
-    var attr = results[i];
-    meta[attr.k] = attr.v;
+  if (results) {
+    for (var i=0; i < results.length; i++) {
+      var attr = results[i];
+      meta[attr.k] = attr.v;
+    }
   }
 
   return meta;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -33,4 +33,14 @@ describe('#PDF', function(){
     })
   })
 
+  it('should not crash when a file is not a PDF', function(done){
+    var pdf = PDF(__dirname + '/pdf/dummy.txt');
+
+    pdf.exec(function(err, meta){
+      if (err) return done(err);
+      meta.should.be.a('object');
+      done();
+    })
+  })
+
 })

--- a/test/pdf/dummy.txt
+++ b/test/pdf/dummy.txt
@@ -1,0 +1,1 @@
+this file is not a PDF.


### PR DESCRIPTION
A little defensive coding so that non-PDF files won't crash node.
