### PR TITLE
Fixed crashes when using node-pdfinfo  

### DIFF
--- a/lib/pdfinfo.js
+++ b/lib/pdfinfo.js
@@ -100,7 +100,7 @@ function parse (str) {
   var meta = [];
   var lines = str.split(/\n/g);
 
-  for (var i=0; i < lines.length; i++) {
+  for (var i in lines) {
     var _attr = lines[i].split(/:\s+/);
     var key = _attr[0];
     var val = _attr[1];
@@ -126,11 +126,10 @@ function map (results) {
 
   var meta = {};
 
-  for (var i=0; i < results.length; i++) {
+  for (var i in results) {
     var attr = results[i];
     meta[attr.k] = attr.v;
   }
-
   return meta;
 }
 


### PR DESCRIPTION
If for a strange reason the `results` variable is `undefined` or `null` in the `map` function the code will break because of the for loop used as bellow:

``` js
// will break because of calling 'length' property on undefined
for(var i = 0; i < results.length ; i++){ 
   var result = results[i];
   // stuff
}
```

A good way to avoid these issues is to use the other for syntax:

``` js
// will not break if results is undefined
for(var i in results){ 
  var result = results[i]; 
  // stuff 
}
```
